### PR TITLE
Provide access to the sheet's persistent id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 fastexcel
 =========
-[![Build Status](https://github.com/ezand/fastexcel/workflows/build/badge.svg)](https://github.com/ezand/fastexcel/actions)
-[![Coverage Status](https://coveralls.io/repos/github/ezand/fastexcel/badge.svg?branch=master)](https://coveralls.io/github/ezand/fastexcel?branch=master)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.ezand/fastexcel/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.ezand/fastexcel)
-[![Javadocs](http://www.javadoc.io/badge/com.ezand/fastexcel.svg)](http://www.javadoc.io/doc/com.ezand/fastexcel)
-
-# Fork
-
-This fork adds the following functionality:
-* Provide access to the persistent sheet id. This id remains the same regardless of rearrangement of sheet order.
-  * `org.dhatim.fastexcel.reader.Sheet/getPersistentId` 
+[![Build Status](https://github.com/dhatim/fastexcel/workflows/build/badge.svg)](https://github.com/dhatim/fastexcel/actions)
+[![Coverage Status](https://coveralls.io/repos/github/dhatim/fastexcel/badge.svg?branch=master)](https://coveralls.io/github/dhatim/fastexcel?branch=master)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.dhatim/fastexcel/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.dhatim/fastexcel)
+[![Javadocs](http://www.javadoc.io/badge/org.dhatim/fastexcel.svg)](http://www.javadoc.io/doc/org.dhatim/fastexcel)
 
 # fastexcel-writer
 
@@ -44,7 +38,7 @@ Note heap memory usage is measured just before flushing the workbook to the outp
 - Include the following dependency in your POM:
 ```xml
 <dependency>
-    <groupId>com.ezand</groupId>
+    <groupId>org.dhatim</groupId>
     <artifactId>fastexcel</artifactId>
     <version>0.15.7</version>
 </dependency>
@@ -52,7 +46,7 @@ Note heap memory usage is measured just before flushing the workbook to the outp
 
 ## Examples
 
-The javadoc for the last release is available [here](http://www.javadoc.io/doc/com.ezand/fastexcel).
+The javadoc for the last release is available [here](http://www.javadoc.io/doc/org.dhatim/fastexcel).
 
 ### Simple workbook
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 fastexcel
 =========
-[![Build Status](https://github.com/dhatim/fastexcel/workflows/build/badge.svg)](https://github.com/dhatim/fastexcel/actions)
-[![Coverage Status](https://coveralls.io/repos/github/dhatim/fastexcel/badge.svg?branch=master)](https://coveralls.io/github/dhatim/fastexcel?branch=master)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.dhatim/fastexcel/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.dhatim/fastexcel)
-[![Javadocs](http://www.javadoc.io/badge/org.dhatim/fastexcel.svg)](http://www.javadoc.io/doc/org.dhatim/fastexcel)
+[![Build Status](https://github.com/ezand/fastexcel/workflows/build/badge.svg)](https://github.com/ezand/fastexcel/actions)
+[![Coverage Status](https://coveralls.io/repos/github/ezand/fastexcel/badge.svg?branch=master)](https://coveralls.io/github/ezand/fastexcel?branch=master)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.ezand/fastexcel/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.ezand/fastexcel)
+[![Javadocs](http://www.javadoc.io/badge/com.ezand/fastexcel.svg)](http://www.javadoc.io/doc/com.ezand/fastexcel)
+
+# Fork
+
+This fork adds the following functionality:
+* Provide access to the persistent sheet id. This id remains the same regardless of rearrangement of sheet order.
+  * `org.dhatim.fastexcel.reader.Sheet/getPersistentId` 
 
 # fastexcel-writer
 
@@ -38,7 +44,7 @@ Note heap memory usage is measured just before flushing the workbook to the outp
 - Include the following dependency in your POM:
 ```xml
 <dependency>
-    <groupId>org.dhatim</groupId>
+    <groupId>com.ezand</groupId>
     <artifactId>fastexcel</artifactId>
     <version>0.15.7</version>
 </dependency>
@@ -46,7 +52,7 @@ Note heap memory usage is measured just before flushing the workbook to the outp
 
 ## Examples
 
-The javadoc for the last release is available [here](http://www.javadoc.io/doc/org.dhatim/fastexcel).
+The javadoc for the last release is available [here](http://www.javadoc.io/doc/com.ezand/fastexcel).
 
 ### Simple workbook
 

--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
@@ -130,6 +130,7 @@ public class ReadableWorkbook implements Closeable {
     private void createSheet(SimpleXmlReader r) {
         String name = r.getAttribute("name");
         String id = r.getAttribute("http://schemas.openxmlformats.org/officeDocument/2006/relationships", "id");
+        String stableId = r.getAttribute("sheetId");
         SheetVisibility sheetVisibility;
         if ("veryHidden".equals(r.getAttribute("state"))) {
             sheetVisibility = SheetVisibility.VERY_HIDDEN;
@@ -139,7 +140,7 @@ public class ReadableWorkbook implements Closeable {
             sheetVisibility = SheetVisibility.VISIBLE;
         }
         int index = sheets.size();
-        sheets.add(new Sheet(this, index, id, name, sheetVisibility));
+        sheets.add(new Sheet(this, index, id, stableId, name, sheetVisibility));
     }
 
     Stream<Row> openStream(Sheet sheet) throws IOException {

--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/Sheet.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/Sheet.java
@@ -25,13 +25,16 @@ public class Sheet {
     private final ReadableWorkbook workbook;
     private final int index;
     private final String id;
+    private final String stableId;
     private final String name;
     private final SheetVisibility visibility;
 
-    Sheet(ReadableWorkbook workbook, int index, String id, String name, SheetVisibility visibility) {
+    Sheet(ReadableWorkbook workbook, int index, String id, String stableId,
+          String name, SheetVisibility visibility) {
         this.workbook = workbook;
         this.index = index;
         this.id = id;
+        this.stableId = stableId;
         this.name = name;
         this.visibility = visibility;
     }
@@ -42,6 +45,10 @@ public class Sheet {
 
     public String getId() {
         return id;
+    }
+
+    public String getStableId() {
+        return stableId;
     }
 
     public String getName() {

--- a/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/FastExcelReaderTest.java
+++ b/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/FastExcelReaderTest.java
@@ -153,6 +153,9 @@ class FastExcelReaderTest {
                 while (it.hasNext()) {
                     Sheet sheetDef = it.next();
 
+                    assertThat(sheetDef.getId()).as("sheet id").isNotNull();
+                    assertThat(sheetDef.getStableId()).as("sheet stable id").isNotNull();
+
                     org.apache.poi.ss.usermodel.Sheet sheet = workbook.getSheetAt(sheetDef.getIndex());
 
                     try (Stream<Row> data = sheetDef.openStream()) {


### PR DESCRIPTION
When accessing sheet information by code, we should be able to reference a stable sheet id that doesn't change based on user input, ie. rearranging or adding sheets.

This PR adds another field `stableId` to the `Sheet` class, and `ReadableWorkbook` populates it based on the XLSX xml content.